### PR TITLE
signal-upgrade close of closed channel

### DIFF
--- a/pkg/api/dynamicmux.go
+++ b/pkg/api/dynamicmux.go
@@ -139,6 +139,11 @@ func (m *dynamicMux) reloadAPIs() {
 }
 
 func (m *dynamicMux) close() {
+	// make sure to close channel only once.
+	// when use "signal-upgrade", easegress will start a new process gracefully,
+	// which may cause the old process be closed twice.
+	// here we use sync.Once to make sure the channel is closed only once.
+	// more discussion here: https://github.com/easegress-io/easegress/issues/1170
 	m.closeOnce.Do(func() {
 		close(m.done)
 	})

--- a/pkg/api/dynamicmux.go
+++ b/pkg/api/dynamicmux.go
@@ -20,6 +20,7 @@ package api
 import (
 	"net/http"
 	"sort"
+	"sync"
 	"sync/atomic"
 
 	"github.com/go-chi/chi/v5"
@@ -32,8 +33,10 @@ import (
 type (
 	dynamicMux struct {
 		server *Server
-		done   chan struct{}
 		router atomic.Value
+
+		done      chan struct{}
+		closeOnce sync.Once
 	}
 )
 
@@ -136,5 +139,7 @@ func (m *dynamicMux) reloadAPIs() {
 }
 
 func (m *dynamicMux) close() {
-	close(m.done)
+	m.closeOnce.Do(func() {
+		close(m.done)
+	})
 }


### PR DESCRIPTION
As discussed in issue #1170 , when use `signal-upgrade` to graceful update easegress, it will cause a panic with message "close of closed channel". Although it not influence the usage of easegress, but we'd better to fix it.

After some carefully digging, here is what happens. When use `signal-upgrade`, `easegress-server` receive a user signal, then graceful upgrade. What happens here is `easegress-server` gracefully closes api-server and starts a new process (like fork, start a new process with original environment and configuration). And when the new process is started, it will send a signal to old process to terminate, which will close the api-server again, cause the panic with message "close of closed channel".
Because both two close of api-server happens in original process, it won't influence the new process.

But since this may influence the core part of easegress. Any fix with a lot of code change may cause potential bugs. So, in this pr, I fix it by making api-server recloseable. 
