### PR TITLE
support egctl get describe different namespace

### DIFF
--- a/build/test/integration_test.go
+++ b/build/test/integration_test.go
@@ -1312,3 +1312,165 @@ filters:
 	// get this body means our pipeline is working.
 	assert.Equal("body from response builder", string(data))
 }
+
+func TestEgctlNamespace(t *testing.T) {
+	assert := assert.New(t)
+	mockNamespace := `
+name: mockNamespace
+kind: MockNamespacer
+namespace: mockNamespace 
+httpservers:
+- kind: HTTPServer
+  name: mock-httpserver
+  port: 10222
+  https: false
+  rules:
+    - paths:
+      - path: /pipeline
+        backend: mock-pipeline
+pipelines:
+- name: mock-pipeline
+  kind: Pipeline
+  flow:
+    - filter: proxy
+  filters:
+    - name: proxy
+      kind: Proxy
+      pools:
+      - servers:
+        - url: http://127.0.0.1:9095
+        - url: http://127.0.0.1:9096
+        loadBalance:
+          policy: roundRobin
+`
+	err := createResource(mockNamespace)
+	assert.Nil(err)
+	defer func() {
+		err := deleteResource("MockNamespacer", "mockNamespace")
+		assert.Nil(err)
+	}()
+
+	httpserver := `
+name: httpserver-test
+kind: HTTPServer
+port: 10181
+https: false
+keepAlive: true
+keepAliveTimeout: 75s
+maxConnection: 10240
+cacheSize: 0
+rules:
+  - paths:
+    - backend: pipeline-test
+`
+	err = createResource(httpserver)
+	assert.Nil(err)
+	defer func() {
+		err := deleteResource("HTTPServer", "httpserver-test")
+		assert.Nil(err)
+	}()
+
+	pipeline := `
+name: pipeline-test
+kind: Pipeline
+flow:
+- filter: proxy
+filters:
+- name: proxy
+  kind: Proxy
+  pools:
+  - servers:
+    - url: http://127.0.0.1:8888
+`
+	err = createResource(pipeline)
+	assert.Nil(err)
+	defer func() {
+		err := deleteResource("Pipeline", "pipeline-test")
+		assert.Nil(err)
+	}()
+
+	// egctl get all
+	{
+		// by default, list resources in "default" namespace
+		cmd := egctlCmd("get", "all")
+		output, stderr, err := runCmd(cmd)
+		assert.Nil(err)
+		assert.Empty(stderr)
+		assert.Contains(output, "httpserver-test")
+		assert.Contains(output, "pipeline-test")
+		assert.NotContains(output, "mock-httpserver")
+		assert.NotContains(output, "mock-pipeline")
+	}
+
+	// egctl get all --all-namespaces
+	{
+		cmd := egctlCmd("get", "all", "--all-namespaces")
+		output, stderr, err := runCmd(cmd)
+		assert.Nil(err)
+		assert.Empty(stderr)
+		assert.Contains(output, "httpserver-test")
+		assert.Contains(output, "pipeline-test")
+		assert.Contains(output, "mock-httpserver")
+		assert.Contains(output, "mock-pipeline")
+	}
+
+	// egctl get all --namespace mockNamespace
+	{
+		cmd := egctlCmd("get", "all", "--namespace", "mockNamespace")
+		output, stderr, err := runCmd(cmd)
+		assert.Nil(err)
+		assert.Empty(stderr)
+		assert.NotContains(output, "httpserver-test")
+		assert.NotContains(output, "pipeline-test")
+		assert.Contains(output, "mock-httpserver")
+		assert.Contains(output, "mock-pipeline")
+	}
+
+	// egctl get all --namespace default
+	{
+		cmd := egctlCmd("get", "all", "--namespace", "default")
+		output, stderr, err := runCmd(cmd)
+		assert.Nil(err)
+		assert.Empty(stderr)
+		assert.Contains(output, "httpserver-test")
+		assert.Contains(output, "pipeline-test")
+		assert.NotContains(output, "mock-httpserver")
+		assert.NotContains(output, "mock-pipeline")
+	}
+
+	// egctl get hs --namespace mockNamespace
+	{
+		cmd := egctlCmd("get", "hs", "--namespace", "mockNamespace")
+		output, stderr, err := runCmd(cmd)
+		assert.Nil(err)
+		assert.Empty(stderr)
+		assert.NotContains(output, "httpserver-test")
+		assert.NotContains(output, "pipeline-test")
+		assert.Contains(output, "mock-httpserver")
+		assert.NotContains(output, "mock-pipeline")
+	}
+
+	// egctl get hs --all-namespaces
+	{
+		cmd := egctlCmd("get", "hs", "--all-namespaces")
+		output, stderr, err := runCmd(cmd)
+		assert.Nil(err)
+		assert.Empty(stderr)
+		assert.Contains(output, "httpserver-test")
+		assert.NotContains(output, "pipeline-test")
+		assert.Contains(output, "mock-httpserver")
+		assert.NotContains(output, "mock-pipeline")
+	}
+
+	// egctl get hs mock-httpserver --namespace mockNamespace -o yaml
+	{
+		cmd := egctlCmd("get", "hs", "mock-httpserver", "--namespace", "mockNamespace", "-o", "yaml")
+		output, stderr, err := runCmd(cmd)
+		assert.Nil(err)
+		assert.Empty(stderr)
+		assert.NotContains(output, "httpserver-test")
+		assert.NotContains(output, "pipeline-test")
+		assert.Contains(output, "mock-httpserver")
+		assert.Contains(output, "port: 10222")
+	}
+}

--- a/cmd/client/commandv2/describe.go
+++ b/cmd/client/commandv2/describe.go
@@ -26,6 +26,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var describeFlags resources.ObjectNamespaceFlags
+
 // DescribeCmd returns describe command.
 func DescribeCmd() *cobra.Command {
 	examples := []general.Example{
@@ -37,6 +39,8 @@ func DescribeCmd() *cobra.Command {
 		{Desc: "Describe all members", Command: "egctl describe member"},
 		{Desc: "Describe a customdata kind", Command: "egctl describe customdatakind <name>"},
 		{Desc: "Describe a customdata of given kind", Command: "egctl describe customdata <kind> <name>"},
+		{Desc: "Describe pipeline resources from all namespaces, including httpservers and pipelines created by IngressController, MeshController and GatewayController", Command: "egctl describe pipeline --all-namespaces"},
+		{Desc: "Describe httpserver resources from a certain namespace", Command: "egctl describe httpserver --namespace <namespace>"},
 		{Desc: "Check all possible api resources", Command: "egctl api-resources"},
 	}
 	cmd := &cobra.Command{
@@ -47,6 +51,11 @@ func DescribeCmd() *cobra.Command {
 		Run:     describeCmdRun,
 	}
 	cmd.Flags().BoolVarP(&general.CmdGlobalFlags.Verbose, "verbose", "v", false, "Print verbose information")
+	cmd.Flags().StringVar(&describeFlags.Namespace, "namespace", "",
+		"namespace is used to describe httpservers and pipelines created by IngressController, MeshController or GatewayController"+
+			"(these objects create httpservers and pipelines in an independent namespace)")
+	cmd.Flags().BoolVar(&describeFlags.AllNamespace, "all-namespaces", false,
+		"describe all resources in all namespaces (including the ones created by IngressController, MeshController and GatewayController that are in an independent namespace)")
 	return cmd
 }
 
@@ -71,7 +80,7 @@ func describeCmdRun(cmd *cobra.Command, args []string) {
 	case resources.Member().Kind:
 		err = resources.DescribeMember(cmd, a)
 	default:
-		err = resources.DescribeObject(cmd, a, kind)
+		err = resources.DescribeObject(cmd, a, kind, &describeFlags)
 	}
 }
 

--- a/cmd/client/commandv2/get.go
+++ b/cmd/client/commandv2/get.go
@@ -75,6 +75,7 @@ func getAllResources(cmd *cobra.Command) error {
 		fmt.Printf("\n")
 	}
 
+	// non-default namespace is not supported for members and custom data kinds.
 	if getFlags.Namespace != "" && getFlags.Namespace != resources.DefaultNamespace {
 		return nil
 	}

--- a/cmd/client/commandv2/get.go
+++ b/cmd/client/commandv2/get.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var getFlags resources.GetObjectFlags
+var getFlags resources.ObjectNamespaceFlags
 
 // GetCmd returns get command.
 func GetCmd() *cobra.Command {

--- a/cmd/client/commandv2/get.go
+++ b/cmd/client/commandv2/get.go
@@ -28,6 +28,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var getFlags resources.GetObjectFlags
+
 // GetCmd returns get command.
 func GetCmd() *cobra.Command {
 	examples := []general.Example{
@@ -41,6 +43,8 @@ func GetCmd() *cobra.Command {
 		{Desc: "Get a customdata kind", Command: "egctl get customdatakind <name>"},
 		{Desc: "Get a customdata of given kind", Command: "egctl get customdata <kind> <name>"},
 		{Desc: "Check all possible api resources", Command: "egctl api-resources"},
+		{Desc: "Check all possible api resources from all namespaces, including httpservers and pipelines created by IngressController, MeshController and GatewayController", Command: "egctl get all --all-namespaces"},
+		{Desc: "Check all possible api resources from certain namespace", Command: "egctl get all --namespace <namespace>"},
 	}
 	cmd := &cobra.Command{
 		Use:     "get",
@@ -49,6 +53,11 @@ func GetCmd() *cobra.Command {
 		Example: createMultiExample(examples),
 		Run:     getCmdRun,
 	}
+	cmd.Flags().StringVar(&getFlags.Namespace, "namespace", "",
+		"namespace is used to get httpservers and pipelines created by IngressController, MeshController or GatewayController"+
+			"(these objects create httpservers and pipelines in an independent namespace)")
+	cmd.Flags().BoolVar(&getFlags.AllNamespace, "all-namespaces", false,
+		"get all resources in all namespaces (including the ones created by IngressController, MeshController and GatewayController that are in an independent namespace)")
 	return cmd
 }
 
@@ -59,11 +68,15 @@ func getAllResources(cmd *cobra.Command) error {
 			errs = append(errs, err.Error())
 		}
 	}
-	err := resources.GetAllObject(cmd)
+	err := resources.GetAllObject(cmd, &getFlags)
 	if err != nil {
 		appendErr(err)
 	} else {
 		fmt.Printf("\n")
+	}
+
+	if getFlags.Namespace != "" && getFlags.Namespace != resources.DefaultNamespace {
+		return nil
 	}
 
 	funcs := []func(*cobra.Command, *general.ArgInfo) error{
@@ -109,7 +122,7 @@ func getCmdRun(cmd *cobra.Command, args []string) {
 	case resources.Member().Kind:
 		err = resources.GetMember(cmd, a)
 	default:
-		err = resources.GetObject(cmd, a, kind)
+		err = resources.GetObject(cmd, a, kind, &getFlags)
 	}
 }
 

--- a/cmd/client/resources/object.go
+++ b/cmd/client/resources/object.go
@@ -415,12 +415,7 @@ func DescribeObject(cmd *cobra.Command, args *general.ArgInfo, kind string, flag
 	//    status: ...
 	//  - node: eg2
 	//    status: ...
-	printNamespace := func(namespace string) {
-		msg := fmt.Sprintf("In Namespace %s:", namespace)
-		fmt.Println(strings.Repeat("=", len(msg)))
-		fmt.Println(msg)
-		fmt.Println(strings.Repeat("=", len(msg)))
-	}
+
 	printSpace := false
 	specs := namespaceSpecs[DefaultNamespace]
 	if len(specs) > 0 {
@@ -444,6 +439,13 @@ func DescribeObject(cmd *cobra.Command, args *general.ArgInfo, kind string, flag
 		printSpace = true
 	}
 	return nil
+}
+
+func printNamespace(ns string) {
+	msg := fmt.Sprintf("In Namespace %s:", ns)
+	fmt.Println(strings.Repeat("=", len(msg)))
+	fmt.Println(msg)
+	fmt.Println(strings.Repeat("=", len(msg)))
 }
 
 // CreateObject creates an object.
@@ -610,8 +612,8 @@ func unmarshalObjectStatusInfo(body []byte, name string) ([]*objectStatusInfo, e
 
 // NodeStatus is the status of a node.
 type NodeStatus struct {
-	Node   string
-	Status map[string]interface{}
+	Node   string                 `json:"node"`
+	Status map[string]interface{} `json:"status"`
 }
 
 const objectStatusKeyInSpec = "allStatus"

--- a/cmd/client/resources/object.go
+++ b/cmd/client/resources/object.go
@@ -65,7 +65,9 @@ func ObjectAPIResources() ([]*api.APIResource, error) {
 }
 
 // trafficObjectStatusNamespace return namespace of traffic object status.
-// to get traffic object status of httpserver of pipeline, we need this function.
+// In easegress, when we put traffic object like httpserver, pipeline into namespace "default",
+// then their status will be put into namespace "eg-traffic-default".
+// the status is updated by TrafficController.
 func trafficObjectStatusNamespace(objectNamespace string) string {
 	return cluster.TrafficNamespace(objectNamespace)
 }
@@ -568,8 +570,8 @@ type ObjectStatus struct {
 func unmarshalObjectStatus(data []byte) (ObjectStatus, error) {
 	var status ObjectStatus
 	err := codectool.Unmarshal(data, &status)
-	// if status.Spec and status.Status is all nil
-	// then means the status is not traffic controller object status.
+	// if status.Spec and status.Status are all nil
+	// then means the status is not traffic controller object status (not httpserver, pipeline).
 	// we need to re-unmarshal to get true status.
 	if status.Spec == nil && status.Status == nil {
 		status.Status = map[string]interface{}{}

--- a/cmd/client/resources/resources.go
+++ b/cmd/client/resources/resources.go
@@ -28,6 +28,8 @@ import (
 	"github.com/megaease/easegress/v2/cmd/client/general"
 )
 
+const DefaultNamespace = "default"
+
 // GetResourceKind returns the kind of the resource.
 func GetResourceKind(arg string) (string, error) {
 	if general.InAPIResource(arg, CustomData()) {

--- a/docs/02.Tutorials/2.1.egctl-Usage.md
+++ b/docs/02.Tutorials/2.1.egctl-Usage.md
@@ -151,6 +151,8 @@ In Easegress, when using `IngressController`, `MeshController`, or `GatewayContr
 ```bash 
 egctl get all --all-namespaces         # view all resources in all namespace.
 egctl get all --namespace default      # view all resources in default namespace.
+egctl describe pipeline --all-namespaces           # describe pipeline resources in all namespace.
+egctl describe httpserver demo --namespace default # describe httpserver demo in default namespace.
 ```
 
 ## Updating resources

--- a/docs/02.Tutorials/2.1.egctl-Usage.md
+++ b/docs/02.Tutorials/2.1.egctl-Usage.md
@@ -144,6 +144,15 @@ egctl describe httpserver              # describe all HTTPServer resource
 egctl describe pipeline pipeline-demo  # describe Pipeline resource with name "pipeline-demo"
 ```
 
+In Easegress, when using `IngressController`, `MeshController`, or `GatewayController`, resources such as `HTTPServers` and `Pipelines` are created in separate namespaces to prevent conflicts. To access these resources, you can utilize the `--namespace` or `--all-namespaces` argument.
+
+> The use of these arguments is relevant only when employing `IngressController`, `MeshController`, or `GatewayController`. Easegress does not support creating resources in different namespaces by using apis or `egctl` command.
+
+```bash 
+egctl get all --all-namespaces         # view all resources in all namespace.
+egctl get all --namespace default      # view all resources in default namespace.
+```
+
 ## Updating resources
 ```bash
 egctl apply -f httpserver-demo-version2.yaml  # update HTTPServer resource

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -118,7 +118,8 @@ func (s *Server) _deleteObject(name string) {
 
 // _getStatusObject returns the status object with the specified name.
 // in easegress, since TrafficController contain multiply namespaces.
-// it need a special prefix to store the status object.
+// and it use special prefix to store status of httpserver, pipeline, or grpcserver.
+// so we need to diff them by using isTraffic. previous, we actually can't get status for business controller like autocertmanager.
 func (s *Server) _getStatusObject(namespace string, name string, isTraffic bool) map[string]interface{} {
 	ns := namespace
 	if ns == "" {

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -116,8 +116,18 @@ func (s *Server) _deleteObject(name string) {
 	}
 }
 
-func (s *Server) _getStatusObject(name string) map[string]interface{} {
-	prefix := s.cluster.Layout().StatusObjectPrefix(cluster.TrafficNamespace(cluster.NamespaceDefault), name)
+// _getStatusObject returns the status object of the name.
+// in easegress, since TrafficController contain multiply namespaces.
+// it need a special prefix to store the status object.
+func (s *Server) _getStatusObject(namespace string, name string, isTraffic bool) map[string]interface{} {
+	ns := namespace
+	if ns == "" {
+		ns = cluster.NamespaceDefault
+	}
+	prefix := s.cluster.Layout().StatusObjectPrefix(ns, name)
+	if isTraffic {
+		prefix = s.cluster.Layout().StatusObjectPrefix(cluster.TrafficNamespace(ns), name)
+	}
 	kvs, err := s.cluster.GetPrefix(prefix)
 	if err != nil {
 		ClusterPanic(err)

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -116,7 +116,7 @@ func (s *Server) _deleteObject(name string) {
 	}
 }
 
-// _getStatusObject returns the status object of the name.
+// _getStatusObject returns the status object with the specified name.
 // in easegress, since TrafficController contain multiply namespaces.
 // it need a special prefix to store the status object.
 func (s *Server) _getStatusObject(namespace string, name string, isTraffic bool) map[string]interface{} {

--- a/pkg/api/object.go
+++ b/pkg/api/object.go
@@ -444,7 +444,7 @@ func getTrafficController(super *supervisor.Supervisor) *trafficcontroller.Traff
 	return tc
 }
 
-func (s *Server) _listAllNamespace() map[string][]*supervisor.Spec {
+func (s *Server) _listAllNamespaces() map[string][]*supervisor.Spec {
 	tc := getTrafficController(s.super)
 	if tc == nil {
 		return nil

--- a/pkg/api/object.go
+++ b/pkg/api/object.go
@@ -348,13 +348,13 @@ func (s *Server) listObjects(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if allNamespaces {
-		allSpecs := s._listAllNamespace()
+		allSpecs := s._listAllNamespaces()
 		allSpecs[DefaultNamespace] = s._listObjects()
 		WriteBody(w, r, allSpecs)
 		return
 	}
 	if namespace != "" && namespace != DefaultNamespace {
-		specs := s._listNamespace(namespace)
+		specs := s._listNamespaces(namespace)
 		WriteBody(w, r, specs)
 		return
 	}

--- a/pkg/api/object.go
+++ b/pkg/api/object.go
@@ -461,7 +461,7 @@ func (s *Server) _listAllNamespaces() map[string][]*supervisor.Spec {
 	return res
 }
 
-func (s *Server) _listNamespace(ns string) []*supervisor.Spec {
+func (s *Server) _listNamespaces(ns string) []*supervisor.Spec {
 	tc := getTrafficController(s.super)
 	if tc == nil {
 		return nil

--- a/pkg/api/registry.go
+++ b/pkg/api/registry.go
@@ -20,9 +20,23 @@ package api
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/megaease/easegress/v2/pkg/object/trafficcontroller"
 	"github.com/megaease/easegress/v2/pkg/supervisor"
 )
+
+func init() {
+	// to avoid import cycle
+	RegisterObject(&APIResource{
+		Category: trafficcontroller.Category,
+		Kind:     trafficcontroller.Kind,
+		Name:     strings.ToLower(trafficcontroller.Kind),
+		Aliases:  []string{"trafficcontroller", "tc"},
+	})
+}
+
+const DefaultNamespace = "default"
 
 type (
 	APIResource struct {

--- a/pkg/object/mock/namespacer.go
+++ b/pkg/object/mock/namespacer.go
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package mock implements some mock objects.
+package mock
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/megaease/easegress/v2/pkg/api"
+	"github.com/megaease/easegress/v2/pkg/logger"
+	"github.com/megaease/easegress/v2/pkg/object/httpserver"
+	"github.com/megaease/easegress/v2/pkg/object/pipeline"
+	"github.com/megaease/easegress/v2/pkg/object/trafficcontroller"
+	"github.com/megaease/easegress/v2/pkg/supervisor"
+	"github.com/megaease/easegress/v2/pkg/util/codectool"
+)
+
+const (
+	// Category is the category of MockNamespacer.
+	Category = supervisor.CategoryBusinessController
+	// Kind is the kind of MockNamespacer
+	Kind = "MockNamespacer"
+)
+
+func init() {
+	supervisor.Register(&MockNamespacer{})
+	api.RegisterObject(&api.APIResource{
+		Category: Category,
+		Kind:     Kind,
+		Name:     strings.ToLower(Kind),
+		Aliases:  []string{"mocknamespacer"},
+	})
+}
+
+type (
+	// MockNamespacer create a mock namespace for test
+	MockNamespacer struct {
+		spec *Spec
+		tc   *trafficcontroller.TrafficController
+	}
+
+	// Spec is the MockNamespacer spec
+	Spec struct {
+		Namespace   string            `json:"namespace"`
+		HTTPServers []NamedHTTPServer `json:"httpServers"`
+		Pipelines   []NamedPipeline   `json:"pipelines"`
+	}
+
+	NamedPipeline struct {
+		Kind          string `json:"kind"`
+		Name          string `json:"name"`
+		pipeline.Spec `json:",inline"`
+	}
+
+	NamedHTTPServer struct {
+		Kind            string `json:"kind"`
+		Name            string `json:"name"`
+		httpserver.Spec `json:",inline"`
+	}
+)
+
+// Validate validates the MockNamespacer Spec.
+func (spec *Spec) Validate() error {
+	if spec.Namespace == "" {
+		return fmt.Errorf("namespace is empty")
+	}
+	for _, server := range spec.HTTPServers {
+		if server.Name == "" {
+			return fmt.Errorf("httpserver name is empty")
+		}
+	}
+	for _, pipeline := range spec.Pipelines {
+		if pipeline.Name == "" {
+			return fmt.Errorf("pipeline name is empty")
+		}
+	}
+	return nil
+}
+
+// Category returns the category of MockNamespacer.
+func (mn *MockNamespacer) Category() supervisor.ObjectCategory {
+	return Category
+}
+
+// Kind returns the kind of MockNamespacer.
+func (mn *MockNamespacer) Kind() string {
+	return Kind
+}
+
+// DefaultSpec returns the default spec of MockNamespacer.
+func (mn *MockNamespacer) DefaultSpec() interface{} {
+	return &Spec{}
+}
+
+// Init initializes MockNamespacer.
+func (mn *MockNamespacer) Init(superSpec *supervisor.Spec) {
+	spec := superSpec.ObjectSpec().(*Spec)
+	mn.spec = spec
+	mn.tc = getTrafficController(superSpec.Super())
+
+	for _, server := range mn.spec.HTTPServers {
+		jsonConfig, err := codectool.MarshalJSON(server)
+		if err != nil {
+			logger.Errorf("marshal httpserver failed: %v", err)
+			continue
+		}
+		s, err := supervisor.NewSpec(string(jsonConfig))
+		if err != nil {
+			logger.Errorf("new httpserver spec failed: %v", err)
+			continue
+		}
+		mn.tc.CreateTrafficGateForSpec(spec.Namespace, s)
+	}
+	for _, pipeline := range mn.spec.Pipelines {
+		jsonConfig, err := codectool.MarshalJSON(pipeline)
+		if err != nil {
+			logger.Errorf("marshal pipeline failed: %v", err)
+			continue
+		}
+		s, err := supervisor.NewSpec(string(jsonConfig))
+		if err != nil {
+			logger.Errorf("new pipeline spec failed: %v", err)
+			continue
+		}
+		mn.tc.CreatePipelineForSpec(spec.Namespace, s)
+	}
+}
+
+// Inherit inherits previous generation of MockNamespacer.
+func (mn *MockNamespacer) Inherit(superSpec *supervisor.Spec, previousGeneration supervisor.Object) {
+	previousGeneration.Close()
+	mn.Init(superSpec)
+}
+
+func getTrafficController(super *supervisor.Supervisor) *trafficcontroller.TrafficController {
+	entity, exists := super.GetSystemController(trafficcontroller.Kind)
+	if !exists {
+		return nil
+	}
+	tc, ok := entity.Instance().(*trafficcontroller.TrafficController)
+	if !ok {
+		return nil
+	}
+	return tc
+}
+
+// Status returns the status of MockNamespacer.
+func (mn *MockNamespacer) Status() *supervisor.Status {
+	return &supervisor.Status{
+		ObjectStatus: nil,
+	}
+}
+
+// Close closes MockNamespacer.
+func (mn *MockNamespacer) Close() {
+	for _, server := range mn.spec.HTTPServers {
+		mn.tc.DeleteTrafficGate(mn.spec.Namespace, server.Name)
+	}
+	for _, pipeline := range mn.spec.Pipelines {
+		mn.tc.DeletePipeline(mn.spec.Namespace, pipeline.Name)
+	}
+}

--- a/pkg/object/rawconfigtrafficcontroller/rawconfigtrafficcontroller.go
+++ b/pkg/object/rawconfigtrafficcontroller/rawconfigtrafficcontroller.go
@@ -38,7 +38,7 @@ const (
 	Kind = "RawConfigTrafficController"
 
 	// DefaultNamespace is the namespace of RawConfigTrafficController
-	DefaultNamespace = "default"
+	DefaultNamespace = api.DefaultNamespace
 )
 
 type (

--- a/pkg/object/trafficcontroller/trafficcontroller.go
+++ b/pkg/object/trafficcontroller/trafficcontroller.go
@@ -707,7 +707,7 @@ func (tc *TrafficController) Close() {
 	}
 }
 
-// ListAllNamespace lists all namespaces pipelines and traffic gates.
+// ListAllNamespace lists pipelines and traffic gates in all namespaces.
 func (tc *TrafficController) ListAllNamespace() map[string][]*supervisor.ObjectEntity {
 	tc.mutex.Lock()
 	defer tc.mutex.Unlock()

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -56,6 +56,7 @@ import (
 	_ "github.com/megaease/easegress/v2/pkg/object/httpserver"
 	_ "github.com/megaease/easegress/v2/pkg/object/ingresscontroller"
 	_ "github.com/megaease/easegress/v2/pkg/object/meshcontroller"
+	_ "github.com/megaease/easegress/v2/pkg/object/mock"
 	_ "github.com/megaease/easegress/v2/pkg/object/mqttproxy"
 	_ "github.com/megaease/easegress/v2/pkg/object/nacosserviceregistry"
 	_ "github.com/megaease/easegress/v2/pkg/object/pipeline"


### PR DESCRIPTION
In Easegress, when using `IngressController`, `MeshController`, or `GatewayController`, resources such as `HTTPServers` and `Pipelines` are created in separate namespaces to prevent conflicts. To access these resources, you can utilize the `--namespace` or `--all-namespaces` argument for `egctl get` or `egctl describe` command.

> The use of these arguments is relevant only when employing `IngressController`, `MeshController`, or `GatewayController`. Easegress does not support creating resources in different namespaces by using apis or `egctl` command.

This pr also fix some previous bugs about get status. In easegress, status and config of traffic object are put into different namespace. 
For example, autocertmanager in default namespace, then its status is in default namespace too. But for httpserver (which is traffic object), if httpserver is in default namespace, then its status is in eg-traffic-default. When store status, traffic controller use a special prefix for it.
