### PR TITLE
Fix empty proxy-timeout failure

### DIFF
--- a/pkg/object/ingresscontroller/translator.go
+++ b/pkg/object/ingresscontroller/translator.go
@@ -103,7 +103,7 @@ func (b *pipelineSpecBuilder) addProxy(endpoints []string, ingress *apinetv1.Ing
 	}
 
 	var timeout time.Duration
-	if proxyTimeout == "" {
+	if proxyTimeout != "" {
 		result, err := time.ParseDuration(proxyTimeout)
 		if err != nil {
 			return fmt.Errorf("invalid proxy-timeout: %v", err)


### PR DESCRIPTION
In my last test case, there is always the annotation `easegress.ingress.kubernetes.io/proxy-timeout`, so it didn't fail. But it will fail if there isn't. It may fix the issue https://github.com/easegress-io/easegress/issues/1215 and https://github.com/easegress-io/easegress/issues/1235