### PR TITLE
Fix Content-Length

### DIFF
--- a/pkg/filters/proxies/httpproxy/pool.go
+++ b/pkg/filters/proxies/httpproxy/pool.go
@@ -18,6 +18,7 @@
 package httpproxy
 
 import (
+	"bytes"
 	stdcontext "context"
 	"fmt"
 	"io"
@@ -150,6 +151,16 @@ func (spCtx *serverPoolContext) prepareRequest(pool *ServerPool, svr *Server, ct
 	} else {
 		payload = req.GetPayload()
 	}
+
+	// Keep Content-Length header when the request Content-Length is present.
+	if spCtx.req.IsStream() && spCtx.req.ContentLength > 0 {
+		data, err := io.ReadAll(payload)
+		if err != nil {
+			return err
+		}
+		payload = bytes.NewReader(data)
+	}
+
 	stdr, err := http.NewRequestWithContext(ctx, req.Method(), url, payload)
 	if err != nil {
 		return err


### PR DESCRIPTION
Keep the "Content-Length" of proxy request for stream mode when original request contains "Content-Length".