### PR TITLE
Update GoReleaser configurations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ before:
     - go generate ./...
 
 snapshot:
-  name_template: "{{ .Version }}"
+  version_template: "{{ .Version }}"
 checksum:
   name_template: "checksums.txt"
 
@@ -57,7 +57,8 @@ builds:
 
 archives:
   - id: easegress
-    format: tar.gz
+    formats:
+      - tar.gz
     name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     files:
       - none*


### PR DESCRIPTION
## PR Summary
This small PR updates the GoReleaser configuration to resolve the following warnings which you can find in the [CI logs](https://github.com/easegress-io/easegress/actions/runs/15625719523/job/44019918533#step:5:25): 
```
DEPRECATED:  snapshot.name_template  should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```